### PR TITLE
Only add include/bcrypt as include directory on non-windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,10 @@ set( SRCFILES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/x86.S
 )
 
-include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/include/bcrypt)
+if (NOT WIN32)
+	include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/include/bcrypt)
+endif()
+
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 add_library(


### PR DESCRIPTION
Fixes build errors due to include paths / filename collisions on Windows 10.

I've tested this on Windows 10 19041.264 and Linux (WSL - Ubuntu 16.04) and both platforms now work as expected. This is in reference to issue #15.