### PR TITLE
Fixed compiling with mingw for windows 32 bit

### DIFF
--- a/src/bcrypt.c
+++ b/src/bcrypt.c
@@ -24,7 +24,11 @@
 
 #ifdef _WIN32 || _WIN64
 // On windows we need to generate random bytes differently.
+#if defined(_WIN32) && !defined(_WIN64)
+typedef __int32 ssize_t;
+#elif defined(_WIN32) && defined(_WIN64)
 typedef __int64 ssize_t;
+#endif
 #define BCRYPT_HASHSIZE 60
 
 #include "../include/bcrypt/bcrypt.h"


### PR DESCRIPTION
I was unable to compile this library for Windows 32 bit and fixed the error by doing these minor changes. I don't know if bcrypt is supposed to work on 32-bit machines, but I thought I'll do the PR anyway.